### PR TITLE
Add SQL builder template

### DIFF
--- a/templates/dm/sql_create.html
+++ b/templates/dm/sql_create.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>SQL Builder</title>
+    {{ bootstrap_link|safe }}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/codemirror.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/codemirror.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/mode/sql/sql.min.js"></script>
+    <style>
+        .container {display: flex; gap: 20px; margin-top: 20px;}
+        .left {width: 40%;}
+        .right {flex-grow: 1;}
+        .CodeMirror {height: 400px; border: 1px solid #ccc;}
+    </style>
+</head>
+<body>
+<header>
+    {{ nav_bar|safe }}
+</header>
+<div class="container">
+    <div class="left">
+        <h5>{{ query_description }}</h5>
+        <form id="fieldForm">
+            {% for field in field_set %}
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="field{{ forloop.counter }}" value="{{ field }}" name="fields">
+                <label class="form-check-label" for="field{{ forloop.counter }}">{{ field }}</label>
+            </div>
+            {% endfor %}
+        </form>
+        <button id="buildBtn" class="btn btn-primary mt-2">Build SQL</button>
+    </div>
+    <div class="right">
+        <textarea id="sqlEditor"></textarea>
+    </div>
+</div>
+<script>
+    var editor = CodeMirror.fromTextArea(document.getElementById('sqlEditor'), {
+        mode: 'text/x-sql',
+        lineNumbers: true
+    });
+    var baseQuery = `{{ query_body|escapejs }}`;
+    document.getElementById('buildBtn').addEventListener('click', function(){
+        var selected = Array.from(document.querySelectorAll('input[name="fields"]:checked')).map(function(cb){return cb.value;});
+        var sql = 'SELECT ' + selected.join(', ') + ' FROM (' + baseQuery + ')';
+        editor.setValue(sql);
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add sql_create.html for building a SELECT statement from checked fields and a base query using CodeMirror

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897a41256588333b2e83fd939d46e64